### PR TITLE
Add avg benchmarks

### DIFF
--- a/benchmarks/mlp_benchmarks/__init__.mojo
+++ b/benchmarks/mlp_benchmarks/__init__.mojo
@@ -1,3 +1,8 @@
 from .mlp_imp import *
 from .mlp_func import *
 from .mlp_jit import *
+
+
+from .mlp_imp_avg import *
+from .mlp_func_avg import *
+from .mlp_jit_avg import *

--- a/benchmarks/mlp_benchmarks/mlp_func_avg.mojo
+++ b/benchmarks/mlp_benchmarks/mlp_func_avg.mojo
@@ -1,0 +1,123 @@
+import endia as nd
+import endia.nn as nn
+import endia.optim as optim
+from endia.utils import dtype
+import math
+from time import now
+
+from .utils import benchmark_avg
+
+def fill_sin_(inout curr: nd.Array, arg: nd.Array):
+    """
+    Inplace fill the current array with normalized sin values.
+    """
+    for i in range(arg.size()):
+        curr.store(i, math.sin(50 * (arg.load(i) + 1) / 2))
+
+
+def setup_params(
+    x: nd.Array, y: nd.Array, hidden_dims: List[Int]
+) -> List[nd.Array]:
+    """
+    Setup the parameters for the MLP model as a list of arrays.
+    """
+    params = List[nd.Array]()
+    params.append(x)
+    params.append(y)
+    num_layers = len(hidden_dims) - 1
+    for i in range(num_layers):
+        weight = nd.rand_he_normal(
+            List(hidden_dims[i], hidden_dims[i + 1]),
+            fan_in=hidden_dims[i],
+        )
+        bias = nd.rand_he_normal(
+            List(hidden_dims[i + 1]),
+            fan_in=hidden_dims[i],
+        )
+        params.append(weight)
+        params.append(bias)
+    return params
+
+def benchmark_mlp_func_avg(rounds:Int):
+    benchmark_avg(rounds,_benchmark_mlp_func,"in a functional eager mode with grad")
+
+def _benchmark_mlp_func() -> (Float32,Float64,Float64,Float64):
+   
+    # define the forward function
+    def fwd(args: List[nd.Array]) -> nd.Array:
+        target = args[1]
+        pred = nn.mlp(args)
+        loss = nd.mse(pred, target)
+        return loss
+
+    # define the training loop
+    batch_size = 128
+    lr = 0.001
+    beta1 = 0.9
+    beta2 = 0.999
+    eps = 1e-8
+    num_iters = 1000
+    every = 1000
+    avg_loss = SIMD[dtype, 1](0)
+
+    # setup input, target, params and velocity
+    x = nd.Array(List(batch_size, 1))
+    y = nd.Array(List(batch_size, 1))
+    hidden_dims = List(1, 32, 64, 128, 128, 128, 64, 32, 1)
+    args = setup_params(x, y, hidden_dims)
+    m = List[nd.Array]()
+    v = List[nd.Array]()
+    for i in range(len(args)):
+        m.append(nd.zeros_like(args[i]))
+        v.append(nd.zeros_like(args[i]))
+
+    # setup fwd and grad function as one call
+    value_and_grad_fwd = nd.value_and_grad(fwd)
+
+    # setup time variables
+    start = Float64(0)
+    end = Float64(0)
+    time_all = Float64(0)
+    fwd_start = Float64(0)
+    fwd_end = Float64(0)
+    time_fwd = Float64(0)
+    optim_start = Float64(0)
+    optim_end = Float64(0)
+    time_optim = Float64(0)
+
+    # training loop
+    for t in range(1, num_iters + 1):
+        start = now()
+
+        # fill input and target inplace
+        nd.randu_(args[0])
+        fill_sin_(args[1], args[0])
+
+        # compute loss
+        fwd_start = now()
+        value_and_grad = value_and_grad_fwd(args)[List[List[nd.Array]]]
+        fwd_end = now()
+
+        loss = value_and_grad[0][0]
+        avg_loss += loss.load(0)
+        args_grads = value_and_grad[1]
+
+        # update weights and biases inplace
+        optim_start = now()
+        for i in range(2, len(args_grads)):
+            # implement adam with above variables as in the step function above
+            m[i] = beta1 * m[i] + (1 - beta1) * args_grads[i]
+            v[i] = beta2 * v[i] + (1 - beta2) * args_grads[i] * args_grads[i]
+            m_hat = m[i] / (1 - beta1**t)
+            v_hat = v[i] / (1 - beta2**t)
+            args[i] -= lr * m_hat / (nd.sqrt(v_hat) + eps)
+
+        optim_end = now()
+        end = now()
+
+        time_fwd += (fwd_end - fwd_start) / 1000000000
+        time_optim += (optim_end - optim_start) / 1000000000
+        time_all += (end - start) / 1000000000
+
+        
+    return avg_loss / num_iters,time_all / num_iters,time_fwd / num_iters,time_optim/num_iters

--- a/benchmarks/mlp_benchmarks/mlp_imp_avg.mojo
+++ b/benchmarks/mlp_benchmarks/mlp_imp_avg.mojo
@@ -1,0 +1,73 @@
+import endia as nd
+import endia.nn as nn
+import endia.optim as optim
+from time import now
+
+from .utils import benchmark_avg_2
+
+def fill_sin_(inout curr: nd.Array, arg: nd.Array):
+    for i in range(arg.size()):
+        curr.store(i, math.sin(50 * (arg.load(i) + 1) / 2))
+
+def benchmark_mlp_imp_avg(rounds:Int):
+    benchmark_avg_2(rounds,_benchmark_mlp_imp,"in eager mode")
+
+def _benchmark_mlp_imp() -> (Float32,Float64,Float64,Float64,Float64):
+  
+    batch_size = 128
+    num_iters = 1000
+  
+    avg_loss = SIMD[dtype, 1](0)
+    x = nd.Array(List(batch_size, 1))
+    y = nd.Array(List(batch_size, 1))
+    mlp = nn.MLP(
+        List(1, 32, 64, 128, 128, 128, 64, 32, 1), compute_backward=True
+    )
+    optimizer = optim.Adam(
+        mlp.params(), lr=0.001, beta1=0.9, beta2=0.999, eps=1e-8
+    )
+
+    fwd_time = Float64(0)
+    bwd_time = Float64(0)
+    opt_time = Float64(0)
+    end_time = Float64(0)
+
+    for i in range(1, num_iters + 1):
+        start = now()
+
+        start_init = now()
+        nd.randu_(x, min=0, max=1)
+        fill_sin_(y, x)
+        end_init = now()
+
+        start_fwd = now()
+        pred = mlp.forward(x)
+        loss = nd.mse(pred, y)
+        end_fwd = now()
+
+        if i == 1:
+            nd.utils.visualize_graph(loss, "./assets/mlp_imp_graph")
+
+        avg_loss += loss.load(0)
+
+        start_bwd = now()
+        loss.backward()
+        end_bwd = now()
+
+        start_opt = now()
+        optimizer.step()
+        end_opt = now()
+
+        zero_grad_time_start = now()
+        loss.zero_grad()
+        zero_grad_time_end = now()
+
+        end = now()
+
+        fwd_time += (end_fwd - start_fwd) / 1000000000
+        bwd_time += (end_bwd - start_bwd) / 1000000000
+        opt_time += (end_opt - start_opt) / 1000000000
+        end_time += (end - start) / 1000000000
+
+    return avg_loss / num_iters,end_time / num_iters,fwd_time / num_iters,bwd_time / num_iters,opt_time/num_iters
+       

--- a/benchmarks/mlp_benchmarks/mlp_jit_avg.mojo
+++ b/benchmarks/mlp_benchmarks/mlp_jit_avg.mojo
@@ -1,0 +1,128 @@
+import endia as nd
+import endia.nn as nn
+import endia.optim as optim
+from endia.utils import dtype
+import math
+from time import now
+
+from .utils import benchmark_avg
+
+def fill_sin_(inout curr: nd.Array, arg: nd.Array):
+    """
+    Inplace fill the current array with normalized sin values.
+    """
+    for i in range(arg.size()):
+        curr.store(i, math.sin(50 * (arg.load(i) + 1) / 2))
+
+
+def setup_params(
+    x: nd.Array, y: nd.Array, hidden_dims: List[Int]
+) -> List[nd.Array]:
+    """
+    Setup the parameters for the MLP model as a list of arrays.
+    """
+    params = List[nd.Array]()
+    params.append(x)
+    params.append(y)
+    num_layers = len(hidden_dims) - 1
+    for i in range(num_layers):
+        weight = nd.rand_he_normal(
+            List(hidden_dims[i], hidden_dims[i + 1]),
+            fan_in=hidden_dims[i],
+        )
+        bias = nd.rand_he_normal(
+            List(hidden_dims[i + 1]),
+            fan_in=hidden_dims[i],
+        )
+        params.append(weight)
+        params.append(bias)
+    return params
+
+
+def benchmark_mlp_jit_avg(rounds:Int):
+    benchmark_avg(rounds,_benchmark_mlp_jit,"with MAX JIT compilation")
+
+
+def _benchmark_mlp_jit() -> (Float32,Float64,Float64,Float64):
+  
+    # define the forward function
+    def fwd(args: List[nd.Array]) -> nd.Array:
+        target = args[1]
+        pred = nn.mlp(args)
+        loss = nd.mse(pred, target)
+        return loss
+
+    # define the training loop
+    batch_size = 128
+    lr = 0.001
+    beta1 = 0.9
+    beta2 = 0.999
+    eps = 1e-8
+    num_iters = 1000
+    every = 1000
+    avg_loss = SIMD[dtype, 1](0)
+
+    # setup input, target, params and velocity
+    x = nd.Array(List(batch_size, 1))
+    y = nd.Array(List(batch_size, 1))
+    hidden_dims = List(1, 32, 64, 128, 128, 128, 64, 32, 1)
+    args = setup_params(x, y, hidden_dims)
+    m = List[nd.Array]()
+    v = List[nd.Array]()
+    for i in range(len(args)):
+        m.append(nd.zeros_like(args[i]))
+        v.append(nd.zeros_like(args[i]))
+
+    # setup fwd and grad function as one call
+    value_and_grad_fwd = nd.jit(nd.value_and_grad(fwd), compile_with_MAX=True)
+
+    # setup time variables
+    start = Float64(0)
+    end = Float64(0)
+    time_all = Float64(0)
+    fwd_start = Float64(0)
+    fwd_end = Float64(0)
+    time_fwd = Float64(0)
+    grad_start = Float64(0)
+    grad_end = Float64(0)
+    time_grad = Float64(0)
+    optim_start = Float64(0)
+    optim_end = Float64(0)
+    time_optim = Float64(0)
+
+    # training loop
+    for t in range(1, num_iters + 1):
+        start = now()
+
+        # fill input and target inplace
+        nd.randu_(args[0])
+        fill_sin_(args[1], args[0])
+
+        # compute loss
+        fwd_start = now()
+        value_and_grad = value_and_grad_fwd(args)[List[List[nd.Array]]]
+        fwd_end = now()
+
+        loss = value_and_grad[0][0]
+        avg_loss += loss.load(0)
+        args_grads = value_and_grad[1]
+
+        # update weights and biases inplace
+        optim_start = now()
+        for i in range(2, len(args_grads)):
+            # implement adam with above variables as in the step function above
+            m[i] = beta1 * m[i] + (1 - beta1) * args_grads[i]
+            v[i] = beta2 * v[i] + (1 - beta2) * args_grads[i] * args_grads[i]
+            m_hat = m[i] / (1 - beta1**t)
+            v_hat = v[i] / (1 - beta2**t)
+            args[i] -= lr * m_hat / (nd.sqrt(v_hat) + eps)
+
+        optim_end = now()
+        end = now()
+
+        time_fwd += (fwd_end - fwd_start) / 1000000000
+        time_optim += (optim_end - optim_start) / 1000000000
+        time_all += (end - start) / 1000000000
+
+    return avg_loss / num_iters,time_all / num_iters,time_fwd / num_iters,time_optim/num_iters
+     

--- a/benchmarks/mlp_benchmarks/utils.mojo
+++ b/benchmarks/mlp_benchmarks/utils.mojo
@@ -1,0 +1,75 @@
+alias BENCHMARK_FUNC = def () -> (Float32,Float64,Float64,Float64)
+alias BENCHMARK_FUNC_2 = def () -> (Float32,Float64,Float64,Float64,Float64)
+
+def benchmark_avg(rounds:Int,benchmark_func:BENCHMARK_FUNC,func_text:String):
+    print("\nRunning MLP benchmark",func_text,rounds,"times:")
+
+    loss = Float32(0)
+    time_all = Float64(0)
+    time_fwd = Float64(0)
+    time_optim = Float64(0)
+
+    loss_total = Float32(0)
+    time_all_total = Float64(0)
+    time_fwd_total = Float64(0)
+    time_optim_total = Float64(0)
+
+    for _ in range(rounds):
+        loss,time_all,time_fwd,time_optim = benchmark_func()
+
+        loss_total += loss
+        time_all_total += time_all
+        time_fwd_total += time_fwd
+        time_optim_total += time_optim
+
+    # print loss
+    print("Iter: ", rounds,"x",1000, " Avg Loss: ", loss_total/rounds)
+    
+    print(
+        "Avg Total: ",
+        time_all_total/rounds,
+        " Avg Value_and_Grad: ",
+        time_fwd_total/rounds,
+        " Avg Optim: ",
+        time_optim_total/rounds,
+    )
+   
+
+def benchmark_avg_2(rounds:Int,benchmark_func:BENCHMARK_FUNC_2,func_text:String):
+    print("\nRunning MLP benchmark",func_text,rounds,"times:")
+
+    loss = Float32(0)
+    time_all = Float64(0)
+    time_fwd = Float64(0)
+    time_bwd = Float64(0)
+    time_optim = Float64(0)
+
+    loss_total = Float32(0)
+    time_all_total = Float64(0)
+    time_fwd_total = Float64(0)
+    time_bwd_total = Float64(0)
+    time_optim_total = Float64(0)
+
+    for _ in range(rounds):
+        loss,time_all,time_fwd,time_bwd,time_optim = benchmark_func()
+
+        loss_total += loss
+        time_all_total += time_all
+        time_fwd_total += time_fwd
+        time_bwd_total += time_bwd
+        time_optim_total += time_optim
+
+    # print loss
+    print("Iter: ", rounds,"x",1000, " Avg Loss: ", loss_total/rounds)
+    
+    print(
+        "Avg Total: ",
+        time_all_total/rounds,
+        " Avg Fwd: ",
+        time_fwd_total/rounds,
+        " Avg Bwd: ",
+        time_bwd_total/rounds,
+        " Avg Optim: ",
+        time_optim_total/rounds,
+    )
+   


### PR DESCRIPTION
Implemented mlp benchmarks over multiple rounds to calculate average results. 

Usage:

```
from benchmarks import *

alias ROUNDS = 10

fn main() raises:

    benchmark_mlp_imp_avg(ROUNDS)
    benchmark_mlp_func_avg(ROUNDS)
    benchmark_mlp_jit_avg(ROUNDS)
```
 